### PR TITLE
Guide users who upload the basic Spotify 'Account data' export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ coverage.xml
 
 # DS Store
 **/.DS_Store
+
+# Spotify data exports (user-uploaded test data — never commit)
+*.zip
+my_spotify_data*
+Spotify Account Data/

--- a/app/routers/backfill.py
+++ b/app/routers/backfill.py
@@ -27,6 +27,19 @@ router = APIRouter(prefix="/backfill", tags=["backfill"])
 BACKFILL_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 FILE_PREFIX = "Streaming_History_Audio"
 FILE_SUFFIX = ".json"
+# Marker files that only appear in the basic "Account data" export (not the
+# "Extended streaming history" export we actually ingest). The basic export's
+# streaming files are named e.g. "StreamingHistory_music_0.json" (no underscore
+# after "Streaming") and lack spotify_track_uri, so they can't be ingested.
+BASIC_EXPORT_PREFIX = "StreamingHistory"
+BASIC_EXPORT_MARKERS = ("YourLibrary.json", "Marquee.json", "Inferences.json")
+BASIC_EXPORT_MESSAGE = (
+    "This looks like the basic \"Account data\" export, which only covers the "
+    "last ~12 months and doesn't include the data we need. Please request the "
+    "\"Extended streaming history\" export instead (Spotify → Account → "
+    "Privacy settings → Download your data → Extended streaming history). "
+    "It can take up to 30 days to arrive but contains your full listening history."
+)
 MIN_PLAY_TIME_MS = 30000
 TRACK_URI_PREFIX = "spotify:track:"
 MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MB
@@ -80,6 +93,27 @@ def _extract_json_from_zip(content: bytes) -> list[dict]:
                 except json.JSONDecodeError:
                     continue
     return all_listens
+
+
+def _is_basic_export(content: bytes) -> bool:
+    """Detect the basic "Account data" export, which we can't ingest.
+
+    Returns True if the ZIP contains basic-export streaming files
+    (StreamingHistory_*.json) or other basic-export-only marker files but
+    no "Extended streaming history" audio files.
+    """
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(content))
+    except zipfile.BadZipFile:
+        return False
+
+    for name in zf.namelist():
+        basename = name.split("/")[-1]
+        if basename.startswith(BASIC_EXPORT_PREFIX) and basename.endswith(FILE_SUFFIX):
+            return True
+        if basename in BASIC_EXPORT_MARKERS:
+            return True
+    return False
 
 
 def _validate_and_process_listens(
@@ -266,6 +300,10 @@ def upload_data_export(
 
     raw_listens = _extract_json_from_zip(content)
     if not raw_listens:
+        if _is_basic_export(content):
+            log_action(db, "backfill.upload", user_id=user.user_id, status="error",
+                       details={"reason": "basic_export_uploaded"})
+            raise HTTPException(status_code=400, detail=BASIC_EXPORT_MESSAGE)
         log_action(db, "backfill.upload", user_id=user.user_id, status="error",
                    details={"reason": "no_streaming_history_files"})
         raise HTTPException(status_code=400, detail="No streaming history files found in the ZIP")

--- a/tests/test_app/test_backfill.py
+++ b/tests/test_app/test_backfill.py
@@ -5,7 +5,11 @@ from unittest.mock import patch, MagicMock
 from datetime import date
 
 from app.models import Album, Listen, ListenSource, Track
-from app.routers.backfill import _extract_json_from_zip, _validate_and_process_listens
+from app.routers.backfill import (
+    _extract_json_from_zip,
+    _is_basic_export,
+    _validate_and_process_listens,
+)
 
 
 def _make_zip(files: dict[str, list[dict]]) -> io.BytesIO:
@@ -63,6 +67,49 @@ class TestUploadEndpoint:
             files={"file": ("data.txt", b"not a zip", "text/plain")},
         )
         assert resp.status_code == 400
+
+    def test_upload_rejects_basic_export_with_guidance(self, client, seeded_db, auth_headers):
+        # The basic "Account data" export: StreamingHistory_music_*.json with
+        # endTime/artistName/trackName/msPlayed (no spotify_track_uri).
+        basic = [{
+            "endTime": "2025-05-25 22:00",
+            "artistName": "Klangspiel",
+            "trackName": "Brown Noise Focus Flow",
+            "msPlayed": 59814,
+        }]
+        zip_buf = _make_zip({
+            "Spotify Account Data/StreamingHistory_music_0.json": basic,
+            "Spotify Account Data/YourLibrary.json": [{"x": 1}],
+        })
+        resp = client.post(
+            "/backfill/upload",
+            headers=auth_headers,
+            files={"file": ("my_spotify_data.zip", zip_buf, "application/zip")},
+        )
+        assert resp.status_code == 400
+        assert "Extended streaming history" in resp.json()["detail"]
+
+
+class TestBasicExportDetection:
+    def test_detects_basic_streaming_history_file(self):
+        content = _make_zip_bytes({
+            "Spotify Account Data/StreamingHistory_music_0.json": [{"a": 1}],
+        })
+        assert _is_basic_export(content) is True
+
+    def test_detects_basic_export_marker_file(self):
+        content = _make_zip_bytes({"Spotify Account Data/YourLibrary.json": [{"a": 1}]})
+        assert _is_basic_export(content) is True
+
+    def test_extended_export_not_flagged_as_basic(self):
+        content = _make_zip_bytes({
+            "Streaming_History_Audio_2024_0.json": [_make_listen_json()],
+        })
+        assert _is_basic_export(content) is False
+
+    def test_unrelated_zip_not_flagged_as_basic(self):
+        content = _make_zip_bytes({"random_file.json": [{"a": 1}]})
+        assert _is_basic_export(content) is False
 
 
 class TestExtractJson:


### PR DESCRIPTION
The backfill parser only ingests 'Extended streaming history' exports (Streaming_History_Audio*.json). Users who upload the basic 'Account data' export hit a confusing 'No streaming history files found' error, since that export uses StreamingHistory_*.json files with no spotify_track_uri.

- Detect the basic export (_is_basic_export) and return a clear 400 telling the user to request the Extended streaming history export instead.
- Log reason=basic_export_uploaded for these rejections.
- Ignore *.zip and Spotify export files so user data is never committed.
- Add tests for the detector and the endpoint guidance message.